### PR TITLE
Add option to prompt user for installs when privileged

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppListScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppListScreen.kt
@@ -22,12 +22,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import app.accrescent.client.R
 import app.accrescent.client.data.InstallStatus
+import app.accrescent.client.util.isPrivileged
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -38,8 +40,10 @@ fun AppListScreen(
     padding: PaddingValues,
     viewModel: AppListViewModel = viewModel(),
 ) {
+    val context = LocalContext.current
     val apps by viewModel.apps.collectAsState(emptyList())
     val installStatuses = viewModel.installStatuses
+    val requireUserAction by viewModel.requireUserAction.collectAsState(!context.isPrivileged())
 
     val refreshScope = rememberCoroutineScope()
     val state = rememberPullRefreshState(viewModel.isRefreshing, onRefresh = {
@@ -69,6 +73,7 @@ fun AppListScreen(
                         onInstallClicked = viewModel::installApp,
                         onUninstallClicked = viewModel::uninstallApp,
                         onOpenClicked = viewModel::openApp,
+                        requireUserAction = requireUserAction,
                     )
                 }
             }

--- a/app/src/main/java/app/accrescent/client/ui/AppListViewModel.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppListViewModel.kt
@@ -11,6 +11,7 @@ import app.accrescent.client.Accrescent
 import app.accrescent.client.R
 import app.accrescent.client.data.AppInstallStatuses
 import app.accrescent.client.data.InstallStatus
+import app.accrescent.client.data.PreferencesManager
 import app.accrescent.client.data.RepoDataRepository
 import app.accrescent.client.util.PackageManager
 import app.accrescent.client.util.UserRestrictionException
@@ -33,9 +34,11 @@ class AppListViewModel @Inject constructor(
     @ApplicationContext context: Context,
     private val repoDataRepository: RepoDataRepository,
     private val packageManager: PackageManager,
+    preferencesManager: PreferencesManager,
     appInstallStatuses: AppInstallStatuses,
 ) : AndroidViewModel(context as Application) {
     val apps = repoDataRepository.getApps()
+    val requireUserAction = preferencesManager.requireUserAction
 
     // Initialize install status for apps as they're added
     init {
@@ -92,14 +95,14 @@ class AppListViewModel @Inject constructor(
         }
     }
 
-    fun installApp(appId: String) {
+    fun installApp(appId: String, requireUserAction: Boolean) {
         viewModelScope.launch {
             error = null
 
             val context = getApplication<Accrescent>().applicationContext
 
             try {
-                packageManager.downloadAndInstall(appId)
+                packageManager.downloadAndInstall(appId, requireUserAction)
             } catch (e: ConnectException) {
                 error = context.getString(R.string.network_error, e.message)
             } catch (e: FileNotFoundException) {

--- a/app/src/main/java/app/accrescent/client/ui/AppUpdatesScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppUpdatesScreen.kt
@@ -19,15 +19,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import app.accrescent.client.R
 import app.accrescent.client.data.InstallStatus
+import app.accrescent.client.util.isPrivileged
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -38,9 +43,12 @@ fun AppUpdatesScreen(
     padding: PaddingValues,
     viewModel: AppListViewModel = viewModel(),
 ) {
+    val context = LocalContext.current
     val apps by viewModel.apps.collectAsState(emptyList())
     val installStatuses = viewModel.installStatuses
     val updatableApps = apps.filter { installStatuses[it.id] == InstallStatus.UPDATABLE }
+
+    var uninstallConfirmDialogAppId: String? by remember { mutableStateOf(null) }
 
     val refreshScope = rememberCoroutineScope()
     val state = rememberPullRefreshState(viewModel.isRefreshing, onRefresh = {
@@ -71,7 +79,16 @@ fun AppUpdatesScreen(
                         installStatus = installStatuses[app.id] ?: InstallStatus.LOADING,
                         onClick = { navController.navigate("${Screen.AppDetails.route}/${app.id}") },
                         onInstallClicked = viewModel::installApp,
-                        onUninstallClicked = viewModel::uninstallApp,
+                        onUninstallClicked = {
+                            // When uninstalling in privileged mode, the OS doesn't create a
+                            // confirmation dialog. To prevent users from mistakenly deleting
+                            // important app data, create our own dialog in this case.
+                            if (context.isPrivileged()) {
+                                uninstallConfirmDialogAppId = app.id
+                            } else {
+                                viewModel.uninstallApp(app.id)
+                            }
+                        },
                         onOpenClicked = viewModel::openApp,
                     )
                 }
@@ -91,6 +108,14 @@ fun AppUpdatesScreen(
             modifier = Modifier.align(Alignment.TopCenter),
             backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
             contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+
+    if (uninstallConfirmDialogAppId != null) {
+        UninstallConfirmDialog(
+            appId = uninstallConfirmDialogAppId!!,
+            onDismiss = { uninstallConfirmDialogAppId = null },
+            onConfirm = { viewModel.uninstallApp(uninstallConfirmDialogAppId!!) }
         )
     }
 }

--- a/app/src/main/java/app/accrescent/client/ui/InstallableAppCard.kt
+++ b/app/src/main/java/app/accrescent/client/ui/InstallableAppCard.kt
@@ -26,9 +26,10 @@ fun InstallableAppCard(
     app: App,
     installStatus: InstallStatus,
     onClick: () -> Unit,
-    onInstallClicked: (String) -> Unit,
+    onInstallClicked: (String, requireUserAction: Boolean) -> Unit,
     onUninstallClicked: (String) -> Unit,
     onOpenClicked: (String) -> Unit,
+    requireUserAction: Boolean = false,
 ) {
     Card(
         Modifier
@@ -62,8 +63,8 @@ fun InstallableAppCard(
                     modifier = Modifier.padding(end = 16.dp, top = 12.dp, bottom = 12.dp),
                     onClick = {
                         when (installStatus) {
-                            InstallStatus.INSTALLABLE,
-                            InstallStatus.UPDATABLE -> onInstallClicked(app.id)
+                            InstallStatus.INSTALLABLE -> onInstallClicked(app.id, requireUserAction)
+                            InstallStatus.UPDATABLE -> onInstallClicked(app.id, false)
                             InstallStatus.INSTALLED -> onOpenClicked(app.id)
                             InstallStatus.LOADING,
                             InstallStatus.UNKNOWN -> Unit

--- a/app/src/main/java/app/accrescent/client/ui/SettingsScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.accrescent.client.R
 import app.accrescent.client.data.SOURCE_CODE_URL
+import app.accrescent.client.util.isPrivileged
 import kotlinx.coroutines.launch
 
 @Composable
@@ -36,12 +37,24 @@ fun SettingsScreen(padding: PaddingValues, viewModel: SettingsViewModel) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val dynamicColor by viewModel.dynamicColor.collectAsState(false)
+    val requireUserAction by viewModel.requireUserAction.collectAsState(!context.isPrivileged())
 
     Column(
         modifier = Modifier
             .padding(padding)
             .padding(horizontal = 32.dp)
     ) {
+        SettingGroupLabel(stringResource(R.string.app_updates))
+        Setting(
+            label = stringResource(R.string.require_user_action),
+            description = stringResource(R.string.require_user_action_desc),
+        ) {
+            Switch(
+                checked = requireUserAction,
+                onCheckedChange = { coroutineScope.launch { viewModel.setRequireUserAction(it) } },
+                enabled = context.isPrivileged(),
+            )
+        }
         SettingGroupLabel(stringResource(R.string.customization))
         Setting(
             label = stringResource(R.string.dynamic_color),

--- a/app/src/main/java/app/accrescent/client/ui/SettingsViewModel.kt
+++ b/app/src/main/java/app/accrescent/client/ui/SettingsViewModel.kt
@@ -9,7 +9,11 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(private val preferencesManager: PreferencesManager) :
     ViewModel() {
     val dynamicColor = preferencesManager.dynamicColor
+    val requireUserAction = preferencesManager.requireUserAction
 
     suspend fun setDynamicColor(dynamicColor: Boolean) =
         preferencesManager.setDynamicColor(dynamicColor)
+
+    suspend fun setRequireUserAction(requireUserAction: Boolean) =
+        preferencesManager.setRequireUserAction(requireUserAction)
 }

--- a/app/src/main/java/app/accrescent/client/ui/UninstallConfirmDialog.kt
+++ b/app/src/main/java/app/accrescent/client/ui/UninstallConfirmDialog.kt
@@ -1,0 +1,39 @@
+package app.accrescent.client.ui
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import app.accrescent.client.R
+
+@Composable
+fun UninstallConfirmDialog(
+    appId: String,
+    onDismiss: () -> Unit,
+    onConfirm: (appId: String) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.uninstall_confirm)) },
+        text = {
+            Text(stringResource(R.string.uninstall_confirm_desc), fontFamily = FontFamily.Default)
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm(appId)
+                    onDismiss()
+                },
+                content = { Text(stringResource(R.string.yes)) },
+            )
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                content = { Text(stringResource(R.string.no)) },
+            )
+        },
+    )
+}

--- a/app/src/main/java/app/accrescent/client/util/Util.kt
+++ b/app/src/main/java/app/accrescent/client/util/Util.kt
@@ -1,0 +1,10 @@
+package app.accrescent.client.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+
+fun Context.isPrivileged(): Boolean {
+    return this.checkSelfPermission(Manifest.permission.INSTALL_PACKAGES) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/app/accrescent/client/workers/AutoUpdateWorker.kt
+++ b/app/src/main/java/app/accrescent/client/workers/AutoUpdateWorker.kt
@@ -27,7 +27,7 @@ class AutoUpdateWorker @AssistedInject constructor(
                     repoDataRepository
                         .getAppRepoData(it.packageName)
                         .versionCode > it.longVersionCode
-                }.forEach { packageManager.downloadAndInstall(it.packageName) }
+                }.forEach { packageManager.downloadAndInstall(it.packageName, false) }
         } catch (e: Exception) {
             return Result.failure()
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,8 @@
     <string name="sig_verify_failed">signature verification failed</string>
     <string name="install_blocked">install blocked by admin</string>
     <string name="uninstall_blocked">uninstall blocked by admin</string>
+    <string name="uninstall_confirm">Uninstall this app?</string>
+    <string name="uninstall_confirm_desc">App will be removed from your device along with all of its data.</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="update">Update</string>
     <string name="open">Open</string>
     <string name="unknown" translatable="false">\?\?\?</string>
+    <string name="require_user_action">Install confirmation prompt</string>
+    <string name="require_user_action_desc">Always prompt for confirmation to prevent accidentally installing apps</string>
     <string name="customization">Customization</string>
     <string name="dynamic_color">Dynamic color / Material You</string>
     <string name="dynamic_color_desc">Theme the app based on the system color palette</string>


### PR DESCRIPTION
When Accrescent is privileged, the OS doesn't prompt the user when installing an app. This may be undesirable since the user could accidentally press "Install" on unwanted apps. This commit allows the user to force OS prompts for installations when Accrescent is privileged. Note this doesn't affect app updates i.e. pressing an "Update" button while the option is enabled will not prompt the user.

The option is disabled by default.