### PR TITLE
Add a search view to the top bar

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppList.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppList.kt
@@ -39,10 +39,14 @@ fun AppList(
     viewModel: AppListViewModel = viewModel(),
     filter: (installStatus: InstallStatus) -> Boolean = { true },
     noFilterResultsText: String = "",
+    searchQuery: String
 ) {
     val apps by viewModel.apps.collectAsState(emptyList())
     val installStatuses = viewModel.installStatuses
     val filteredApps = apps.filter { filter(installStatuses[it.id] ?: InstallStatus.LOADING) }
+        .filter { it.name.lowercase().contains(searchQuery.lowercase()) ||
+                it.id.lowercase().contains(searchQuery.lowercase())
+        }
 
     val refreshScope = rememberCoroutineScope()
     val state = rememberPullRefreshState(viewModel.isRefreshing, onRefresh = {

--- a/app/src/main/java/app/accrescent/client/ui/AppList.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppList.kt
@@ -44,8 +44,11 @@ fun AppList(
     val apps by viewModel.apps.collectAsState(emptyList())
     val installStatuses = viewModel.installStatuses
     val filteredApps = apps.filter { filter(installStatuses[it.id] ?: InstallStatus.LOADING) }
-        .filter { it.name.lowercase().contains(searchQuery.lowercase()) ||
-                it.id.lowercase().contains(searchQuery.lowercase())
+        .filter {
+            it.name.lowercase().contains(searchQuery.lowercase())
+        }
+        .sortedBy {
+            it.name.lowercase().indexOf(searchQuery.lowercase())
         }
 
     val refreshScope = rememberCoroutineScope()

--- a/app/src/main/java/app/accrescent/client/ui/AppList.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppList.kt
@@ -44,12 +44,8 @@ fun AppList(
     val apps by viewModel.apps.collectAsState(emptyList())
     val installStatuses = viewModel.installStatuses
     val filteredApps = apps.filter { filter(installStatuses[it.id] ?: InstallStatus.LOADING) }
-        .filter {
-            it.name.lowercase().contains(searchQuery.lowercase())
-        }
-        .sortedBy {
-            it.name.lowercase().indexOf(searchQuery.lowercase())
-        }
+        .filter { it.name.lowercase().contains(searchQuery.lowercase()) }
+        .sortedBy { it.name.lowercase().indexOf(searchQuery.lowercase()) }
 
     val refreshScope = rememberCoroutineScope()
     val state = rememberPullRefreshState(viewModel.isRefreshing, onRefresh = {

--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -118,9 +118,7 @@ fun MainContent(
             if (showBottomBar) surfaceColorEl2 else surfaceColor
         )
     }
-    val searchQuery = remember {
-        mutableStateOf(TextFieldValue())
-    }
+    val searchQuery = remember { mutableStateOf(TextFieldValue()) }
 
     val startDestination =
         if (appId != null) "${Screen.AppDetails.route}/{appId}" else Screen.AppList.route

--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -34,9 +34,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -48,6 +50,7 @@ import androidx.navigation.navDeepLink
 import app.accrescent.client.R
 import app.accrescent.client.data.InstallStatus
 import app.accrescent.client.data.ROOT_DOMAIN
+import app.accrescent.client.ui.common.SearchAppBar
 import app.accrescent.client.ui.theme.AccrescentTheme
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
@@ -115,6 +118,9 @@ fun MainContent(
             if (showBottomBar) surfaceColorEl2 else surfaceColor
         )
     }
+    val searchQuery = remember {
+        mutableStateOf(TextFieldValue())
+    }
 
     val startDestination =
         if (appId != null) "${Screen.AppDetails.route}/{appId}" else Screen.AppList.route
@@ -147,17 +153,14 @@ fun MainContent(
                 enter = fadeIn(animationSpec = tween(400)),
                 exit = fadeOut(animationSpec = tween(400)),
             ) {
-                CenterAlignedTopAppBar(
-                    title = {},
-                    actions = {
-                        IconButton(onClick = { navController.navigate(Screen.Settings.route) }) {
-                            Icon(
-                                imageVector = Screen.Settings.navIconSelected!!,
-                                contentDescription = stringResource(Screen.Settings.resourceId)
-                            )
-                        }
+                SearchAppBar(value = searchQuery) {
+                    IconButton(onClick = { navController.navigate(Screen.Settings.route) }) {
+                        Icon(
+                            imageVector = Screen.Settings.navIconSelected!!,
+                            contentDescription = stringResource(Screen.Settings.resourceId)
+                        )
                     }
-                )
+                }
             }
         },
         bottomBar = {
@@ -223,6 +226,7 @@ fun MainContent(
                     snackbarHostState = snackbarHostState,
                     padding = padding,
                     viewModel = model,
+                    searchQuery = searchQuery.value.text
                 )
             }
             composable(Screen.InstalledApps.route, enterTransition = {
@@ -254,6 +258,7 @@ fun MainContent(
                     viewModel = model,
                     filter = { it == InstallStatus.INSTALLED || it == InstallStatus.UPDATABLE },
                     noFilterResultsText = stringResource(R.string.no_apps_installed),
+                    searchQuery = searchQuery.value.text
                 )
             }
             composable(Screen.AppUpdates.route, enterTransition = {
@@ -283,6 +288,7 @@ fun MainContent(
                     viewModel = model,
                     filter = { it == InstallStatus.UPDATABLE },
                     noFilterResultsText = stringResource(R.string.up_to_date),
+                    searchQuery = searchQuery.value.text
                 )
             }
             composable(

--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -153,7 +153,11 @@ fun MainContent(
                 enter = fadeIn(animationSpec = tween(400)),
                 exit = fadeOut(animationSpec = tween(400)),
             ) {
-                SearchAppBar(value = searchQuery) {
+                SearchAppBar(
+                    value = searchQuery,
+                    // keep the search bar open if query is not empty when returning from an other screen
+                    expandedInitially = searchQuery.value.text.isNotEmpty()
+                ) {
                     IconButton(onClick = { navController.navigate(Screen.Settings.route) }) {
                         Icon(
                             imageVector = Screen.Settings.navIconSelected!!,

--- a/app/src/main/java/app/accrescent/client/ui/common/ExpandableSearchBar.kt
+++ b/app/src/main/java/app/accrescent/client/ui/common/ExpandableSearchBar.kt
@@ -1,0 +1,135 @@
+package app.accrescent.client.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import app.accrescent.client.R
+
+@Composable
+fun SearchIcon() {
+    Icon(
+        imageVector = Icons.Default.Search,
+        contentDescription = stringResource(R.string.search)
+    )
+}
+
+@Composable
+fun CollapsedSearchView(
+    onExpandedChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit,
+    title: String
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .weight(1f)
+        )
+        IconButton(
+            onClick = {
+                onExpandedChanged(true)
+            }
+        ) {
+            SearchIcon()
+        }
+        actions.invoke(this)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpandedSearchView(
+    textFieldValue: MutableState<TextFieldValue>,
+    onSearchDisplayChanged: (String) -> Unit,
+    onSearchDisplayClosed: () -> Unit,
+    onExpandedChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
+
+    val textFieldFocusRequester = remember { FocusRequester() }
+
+    SideEffect {
+        textFieldFocusRequester.requestFocus()
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(end = 15.dp),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(
+            modifier = Modifier.padding(top = 5.dp),
+            onClick = {
+                onExpandedChanged(false)
+                onSearchDisplayClosed()
+            }
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = null
+            )
+        }
+        OutlinedTextField(
+            value = textFieldValue.value,
+            onValueChange = {
+                textFieldValue.value = it
+                onSearchDisplayChanged(it.text)
+            },
+            trailingIcon = {
+                SearchIcon()
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(textFieldFocusRequester),
+            label = {
+                Text(text = stringResource(R.string.search))
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                }
+            )
+        )
+    }
+}

--- a/app/src/main/java/app/accrescent/client/ui/common/ExpandableSearchBar.kt
+++ b/app/src/main/java/app/accrescent/client/ui/common/ExpandableSearchBar.kt
@@ -98,8 +98,9 @@ fun ExpandedSearchView(
         IconButton(
             modifier = Modifier.padding(top = 5.dp),
             onClick = {
-                onExpandedChanged(false)
                 onSearchDisplayClosed()
+                onExpandedChanged(false)
+                textFieldValue.value = TextFieldValue("")
             }
         ) {
             Icon(

--- a/app/src/main/java/app/accrescent/client/ui/common/SearchAppBar.kt
+++ b/app/src/main/java/app/accrescent/client/ui/common/SearchAppBar.kt
@@ -1,0 +1,52 @@
+package app.accrescent.client.ui.common
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchAppBar(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    value: MutableState<TextFieldValue>,
+    onSearchDisplayChanged: (String) -> Unit = {},
+    onSearchDisplayClosed: () -> Unit = {},
+    expandedInitially: Boolean = false,
+    actions: @Composable RowScope.() -> Unit
+) {
+    CenterAlignedTopAppBar(
+        title = {},
+        actions = {
+            val (expanded, onExpandedChanged) = remember {
+                mutableStateOf(expandedInitially)
+            }
+
+            Crossfade(targetState = expanded) { isSearchFieldVisible ->
+                when (isSearchFieldVisible) {
+                    true -> ExpandedSearchView(
+                        textFieldValue = value,
+                        onSearchDisplayChanged = onSearchDisplayChanged,
+                        onSearchDisplayClosed = onSearchDisplayClosed,
+                        onExpandedChanged = onExpandedChanged,
+                        modifier = modifier
+                    )
+
+                    false -> CollapsedSearchView(
+                        onExpandedChanged = onExpandedChanged,
+                        modifier = modifier,
+                        actions = actions,
+                        title = title
+                    )
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,4 +57,5 @@
     <string name="uninstall_confirm_desc">App will be removed from your device along with all of its data.</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="search">Search</string>
 </resources>


### PR DESCRIPTION
closes #21, though tag search is not available yet

Expanded, while searching:
![demo_1](https://user-images.githubusercontent.com/82752168/218524065-825ec06e-9cb7-4c83-a398-8fd208f2e107.png)

Collapsed, default state:
![demo_2](https://user-images.githubusercontent.com/82752168/218524069-288652c9-902f-45c1-8eb6-a1b2b97431eb.png)

It uses both, the app name and the app id to filter apps. 
The PR doesn't include any fancy sorting, for now it only filters and doesn't sort the results.