### PR TITLE
Fix ripple of app list items

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppList.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppList.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -73,6 +75,7 @@ fun AppList(
                         Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .clip(CardDefaults.shape)
                             .clickable { navController.navigate("${Screen.AppDetails.route}/${app.id}") },
                     )
                 }


### PR DESCRIPTION
Currently, when hovering an app item inside the app list, the ripple shown is larger than the card itself and edged, not rounded.
That's what's being fixed with this PR.