### PR TITLE
Use a large top app bar in the settings

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -19,10 +19,13 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -30,6 +33,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -39,6 +44,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -127,7 +133,16 @@ fun MainContent(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
+    val settingsScrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
+        rememberTopAppBarState(),
+    )
+
     Scaffold(
+        modifier = if (currentDestination?.route == Screen.Settings.route) {
+            Modifier.nestedScroll(settingsScrollBehavior.nestedScrollConnection)
+        } else {
+            Modifier
+        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             // This little hack is used to ensure smooth transition animations when navigating
@@ -145,7 +160,15 @@ fun MainContent(
                 enter = fadeIn(animationSpec = tween(400)),
                 exit = fadeOut(animationSpec = tween(400)),
             ) {
-                CenterAlignedTopAppBar(title = { Text(stringResource(R.string.settings)) })
+                LargeTopAppBar(
+                    title = { Text(stringResource(R.string.settings)) },
+                    scrollBehavior = settingsScrollBehavior,
+                    navigationIcon = {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                          Icon(Icons.Default.ArrowBack, null)
+                        }
+                    },
+                )
             }
             AnimatedVisibility(
                 visible = currentDestination?.route != "${Screen.AppDetails.route}/{appId}"

--- a/app/src/main/java/app/accrescent/client/ui/SettingsScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/SettingsScreen.kt
@@ -61,7 +61,7 @@ fun SettingsScreen(modifier: Modifier = Modifier, viewModel: SettingsViewModel =
 
     Column(
         modifier
-            .padding(horizontal = 32.dp)
+            .padding(horizontal = 20.dp)
             .verticalScroll(rememberScrollState()),
     ) {
         if (context.isPrivileged()) {


### PR DESCRIPTION
This PR adds a navigation icon to leave the settings screen as well as a top bar, that collapses automatically on scroll.
This seems to be fitting well here as the app currently doesn't have a lot of settings available in the settings screen and therefore it looks quite well.

![expanded](https://user-images.githubusercontent.com/82752168/231388492-8d581c23-2073-49e9-966f-0f37da55c45f.png)
![collapsed](https://user-images.githubusercontent.com/82752168/231388489-cd00f5fd-f5c1-4ccf-af48-cda906063018.png)
