### PR TITLE
Fix app id being cut/invisible

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppDetailsScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppDetailsScreen.kt
@@ -202,6 +202,7 @@ fun AppDetails(
                                 waitingForSize = true
                                 onInstallClicked()
                             }
+
                             InstallStatus.DISABLED -> onOpenAppInfoClicked()
                             InstallStatus.INSTALLED -> onOpenClicked()
                             InstallStatus.LOADING,
@@ -212,18 +213,23 @@ fun AppDetails(
                     when (installStatus) {
                         InstallStatus.INSTALLABLE ->
                             Text(stringResource(R.string.install))
+
                         InstallStatus.UPDATABLE ->
                             Text(stringResource(R.string.update))
+
                         InstallStatus.DISABLED ->
                             Text(stringResource(R.string.enable))
+
                         InstallStatus.INSTALLED ->
                             Text(stringResource(R.string.open))
+
                         InstallStatus.LOADING ->
                             CircularProgressIndicator(
                                 modifier = Modifier.size(24.dp),
                                 color = MaterialTheme.colorScheme.onPrimary,
                                 strokeWidth = 3.dp
                             )
+
                         InstallStatus.UNKNOWN ->
                             Text(stringResource(R.string.unknown))
                     }
@@ -255,7 +261,7 @@ fun AppDetails(
                 Text("$partMb MB / $totalMb MB", Modifier.padding(top = 16.dp))
             }
 
-            Text(id, Modifier.padding(top = 48.dp))
+            Text(id, Modifier.padding(top = 48.dp, bottom = 24.dp))
         }
     }
 }


### PR DESCRIPTION
Weird, just a simple 24.dp bottom padding was needed. I tested on a Pixel 7 with various font and display sizes. 

Fixes #380 