### PR TITLE
Don't color the system navigation bar

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -1,7 +1,6 @@
 package app.accrescent.client.ui
 
 import android.Manifest
-import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -21,13 +20,11 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
@@ -36,17 +33,13 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -103,19 +96,7 @@ fun MainContent(appId: String?) {
 
     val showBottomBar =
         navController.currentBackStackEntryAsState().value?.destination?.route in screens.map { it.route }
-    val surfaceColor = MaterialTheme.colorScheme.surface.toArgb()
-    val bottomAppBarColor = MaterialTheme
-        .colorScheme
-        .surfaceColorAtElevation(BottomAppBarDefaults.ContainerElevation)
-        .toArgb()
-    val activity = LocalContext.current as? Activity
-    SideEffect {
-        activity?.window?.navigationBarColor = if (showBottomBar) {
-            bottomAppBarColor
-        } else {
-            surfaceColor
-        }
-    }
+
     val searchQuery = remember { mutableStateOf(TextFieldValue()) }
 
     val startDestination =


### PR DESCRIPTION
The bottom navigation bar already accounts for edge-to-edge content so don't color the system navigation bar to improve the look of navigation transitions.

Seeing the app id being cut off by the system navigation bar is part of an existing bug.

Before
![before](https://github.com/accrescent/accrescent/assets/14132249/884fa0e0-8eb3-4019-b9b4-8575f4185a0d)

After
![after](https://github.com/accrescent/accrescent/assets/14132249/a9f9a8b6-7475-4845-86c0-1fd7d18da109)
