### PR TITLE
Sort AppList apps by name instead of package ID, Fixes #650

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppList.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppList.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -100,7 +102,8 @@ fun AppList(
                 item { CenteredText(noFilterResultsText) }
             } else {
                 item { Spacer(Modifier.height(16.dp)) }
-                items(filteredApps, key = { app -> app.id }) { app ->
+                items(filteredApps.sortedBy { a -> a.name.toLowerCase(Locale.current) },
+                    key = { app -> app.id }) { app ->
                     AppCard(
                         app = app,
                         Modifier


### PR DESCRIPTION
Sort apps in `AppList` by name instead of by package ID (which user can't even see until they select  a particular app). 

In my experience with new users of Accrescent the package name sorting was confusing for new users of Accresscent and wasn't what they were expecting coming from other app stores, especially for less technical users.

This is my first PR, let me know if there's anything procedural I'm doing wrong here, Thanks!