### PR TITLE
Fixes Broken AppDetailsScreen in Landscape

### DIFF
--- a/app/src/main/java/app/accrescent/client/ui/AppDetailsScreen.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppDetailsScreen.kt
@@ -5,12 +5,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -44,6 +48,7 @@ fun AppDetailsScreen(
     modifier: Modifier = Modifier,
     viewModel: AppDetailsViewModel = hiltViewModel(),
 ) {
+
     val installStatus = viewModel.installStatuses[viewModel.uiState.appId]
     val downloadProgress = viewModel.downloadProgresses[viewModel.uiState.appId]
 
@@ -98,13 +103,21 @@ fun AppDetails(
     var waitingForSize by remember { mutableStateOf(false) }
 
     Column(
-        modifier.fillMaxSize(),
+        modifier
+            .fillMaxHeight()
+            .wrapContentWidth()
+            .verticalScroll(rememberScrollState()),
+
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         AppIcon(id, Modifier.size(128.dp))
         Spacer(Modifier.size(8.dp))
-        Text(name, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
+        Text(
+            text = name,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold)
         Text(
             text = shortDescription,
             style = MaterialTheme.typography.bodyMedium,
@@ -126,8 +139,9 @@ fun AppDetails(
         }
         Row(
             Modifier
+                .align(Alignment.CenterHorizontally)
                 .fillMaxWidth()
-                .padding(18.dp)
+                .padding(horizontal = 48.dp, vertical = 4.dp)
         ) {
             when (installStatus) {
                 InstallStatus.INSTALLED,
@@ -215,10 +229,7 @@ fun AppDetails(
                 val totalMb = "%.1f".format(downloadProgress.total.toFloat() / 1_000_000)
 
                 Text("$partMb MB / $totalMb MB", Modifier.padding(top = 16.dp))
-            } else {
-                Spacer(modifier = Modifier.size(96.dp))
-                Text("", Modifier.padding(top = 16.dp))
-            }
+            } else { /* do nothing */ }
         }
         Text(id)
     }

--- a/app/src/main/java/app/accrescent/client/ui/AppDetailsViewModel.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppDetailsViewModel.kt
@@ -29,6 +29,7 @@ import java.net.ConnectException
 import java.net.UnknownHostException
 import java.security.GeneralSecurityException
 import javax.inject.Inject
+import androidx.core.net.toUri
 
 @HiltViewModel
 class AppDetailsViewModel @Inject constructor(
@@ -162,7 +163,7 @@ class AppDetailsViewModel @Inject constructor(
         uiState.error = null
 
         val context = getApplication<Accrescent>().applicationContext
-        val uri = Uri.parse("package:$appId")
+        val uri = "package:$appId".toUri()
 
         val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, uri)
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/app/accrescent/client/ui/AppDetailsViewModel.kt
+++ b/app/src/main/java/app/accrescent/client/ui/AppDetailsViewModel.kt
@@ -3,7 +3,6 @@ package app.accrescent.client.ui
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.provider.Settings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
+++ b/app/src/main/java/app/accrescent/client/ui/MainActivity.kt
@@ -134,7 +134,7 @@ fun MainContent(appId: String?, modifier: Modifier = Modifier) {
                 enter = fadeIn(animationSpec = tween(400)),
                 exit = fadeOut(animationSpec = tween(400)),
             ) {
-                CenterAlignedTopAppBar(title = {})
+                // Do nothing, don't include (an empty) top bar on app details screen
             }
             AnimatedVisibility(
                 visible = currentDestination?.route == Screen.Settings.route,
@@ -342,6 +342,7 @@ fun MainContent(appId: String?, modifier: Modifier = Modifier) {
                     }
                 }
             ) {
+
                 AppDetailsScreen(snackbarHostState)
             }
             composable(Screen.Settings.route, enterTransition = {


### PR DESCRIPTION
As mentioned in #307 the AppDetails screen is broken in Landscape. In part this was because it was being cut off by an empty top bar. 

This PR:
- ensures buttons are sensibly centered and padded on AppDetailsScreen whether in landscape/portrait and whether or not an app is installed or not 
- adds vertical scrolling to the AppDetailsScreen incase the content is still cut off on smaller screens when in landscape (or, in portrait when on a reaaallly small screen)


# Before:

## Installed App

### Portrait
![Screenshot_20250422-074648](https://github.com/user-attachments/assets/3f1dc5ec-aa9d-43f9-a3f9-76c6d9df9207)

### Landscape
![Screenshot_20250422-074654](https://github.com/user-attachments/assets/08a5f28a-91c8-413c-9ba2-7267a53abf4c)

## Uninstalled App

### Portrait 
![Screenshot_20250422-074622](https://github.com/user-attachments/assets/bb54a9c9-9762-4247-ae3b-9a967f36444e)

### Landscape
![Screenshot_20250422-074637](https://github.com/user-attachments/assets/e9cf45c4-6733-47d3-94b8-538348e55822)

# After

## Installed App

### Portrait 
![Screenshot_20250422-050344](https://github.com/user-attachments/assets/064be91f-efab-4c72-bd0e-511ec667f909)

### Landscape

![Screenshot_20250422-050353](https://github.com/user-attachments/assets/cf4e2e0b-fd2b-4fed-b5f5-5bb66b794232)

## Uninstalled App

### Portrait
![Screenshot_20250422-050321](https://github.com/user-attachments/assets/fd7253c2-8dba-4239-af81-eca4de0ce89c)

### Landscape 
![Screenshot_20250422-050327](https://github.com/user-attachments/assets/151bb1d0-5b94-4161-b6f1-b54667fc53b0)
