### PR TITLE
Use Long for minVersionCode end-to-end

### DIFF
--- a/app/src/main/java/app/accrescent/client/data/db/App.kt
+++ b/app/src/main/java/app/accrescent/client/data/db/App.kt
@@ -11,6 +11,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "apps")
 data class App(
     @PrimaryKey val id: String,
-    @ColumnInfo(name = "min_version_code") val minVersionCode: Int,
+    @ColumnInfo(name = "min_version_code") val minVersionCode: Long,
     @ColumnInfo(name = "signing_cert_hash") val signingCertHash: String,
 )

--- a/app/src/main/java/app/accrescent/client/data/net/App.kt
+++ b/app/src/main/java/app/accrescent/client/data/net/App.kt
@@ -9,6 +9,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class App(
-    @SerialName("min_version_code") val minVersionCode: Int,
+    @SerialName("min_version_code") val minVersionCode: Long,
     @SerialName("signing_cert_hash") val signingCertHash: String,
 )


### PR DESCRIPTION
Android's PackageInfo.longVersionCode is a Long composed of versionCodeMajor in the upper 32 bits and versionCode in the lower 32 bits. Once an app sets versionCodeMajor >= 1, the resulting longVersionCode exceeds Int.MAX_VALUE.

The repo data App model and Room entity declared min_version_code as Int, which would cause:
  * kotlinx.serialization to throw on JSON ints > 2^31-1, breaking RepositoryRefreshWorker for any repo containing such an app, and
  * silent truncation of larger values when stored to / read from Room.

Downstream consumers (AppDao.getMinVersionCode, RepoDataRepository, AppManager.verifyPackageInfo) already use Long, so this widens only the two remaining Int declarations. Room column affinity is INTEGER for both Int and Long, so no schema migration is required (identityHash is unchanged).